### PR TITLE
HUB, CONSUMER - RabbitMQ 설정 변경

### DIFF
--- a/tracky-consumer/src/main/java/kernel360/trackyconsumer/config/RabbitMQConfig.java
+++ b/tracky-consumer/src/main/java/kernel360/trackyconsumer/config/RabbitMQConfig.java
@@ -4,8 +4,6 @@ import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,7 +37,7 @@ public class RabbitMQConfig {
 	}
 	
 	@Bean
-	public Binding onOffBinding(Queue onOffQueue, TopicExchange exchange) {
+	public Binding onBinding(Queue onOffQueue, TopicExchange exchange) {
 		return BindingBuilder.bind(onOffQueue).to(exchange).with("on");
 	}
 	
@@ -48,26 +46,8 @@ public class RabbitMQConfig {
 		return BindingBuilder.bind(onOffQueue).to(exchange).with("off");
 	}
 
-	// @Bean
-	// public Queue queue() {
-	// 	return new Queue(QUEUE_NAME, true);
-	// }
-
-	// @Bean
-	// public Binding binding(Queue queue, TopicExchange exchange) {
-	// 	return BindingBuilder.bind(queue).to(exchange).with("#");
-	// }
-
 	@Bean
 	public Jackson2JsonMessageConverter messageConverter() {
 		return new Jackson2JsonMessageConverter();
-	}
-
-	// ConnectionFactory는 Spring Boot에서 자동으로 생성해주므로 주입받아 사용한다.
-	@Bean
-	public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
-		RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
-		rabbitTemplate.setMessageConverter(messageConverter());
-		return rabbitTemplate;
 	}
 }

--- a/tracky-consumer/src/main/resources/application.yml
+++ b/tracky-consumer/src/main/resources/application.yml
@@ -1,9 +1,8 @@
 spring:
   config:
     import: classpath:application-common.yml
-  jpa:
-    hibernate:
-      ddl-auto: update
+  profiles:
+    include: rabbitmq
   application:
     name: tracky-consumer
 

--- a/tracky-core/src/main/resources/application-common.yml
+++ b/tracky-core/src/main/resources/application-common.yml
@@ -8,12 +8,6 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-  rabbitmq:
-    host: ${RABBITMQ_HOST}
-    port: ${RABBITMQ_PORT}
-    username: ${RABBITMQ_USER}
-    password: ${RABBITMQ_PASSWORD}
-
   jpa:
     hibernate:
       ddl-auto: none

--- a/tracky-core/src/main/resources/application-rabbitmq.yml
+++ b/tracky-core/src/main/resources/application-rabbitmq.yml
@@ -1,0 +1,7 @@
+# application-rabbitmq.yml - RabbitMQ 설정만 포함
+spring:
+    rabbitmq:
+        host: ${RABBITMQ_HOST}
+        port: ${RABBITMQ_PORT}
+        username: ${RABBITMQ_USER}
+        password: ${RABBITMQ_PASSWORD}

--- a/tracky-hub/src/main/java/kernel360trackybe/trackyhub/config/RabbitMQConfig.java
+++ b/tracky-hub/src/main/java/kernel360trackybe/trackyhub/config/RabbitMQConfig.java
@@ -1,8 +1,5 @@
 package kernel360trackybe.trackyhub.config;
 
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.BindingBuilder;
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -14,55 +11,13 @@ import org.springframework.context.annotation.Configuration;
 public class RabbitMQConfig {
 
 	public static final String EXCHANGE_NAME = "car-info-exchange";
-	// public static final String QUEUE_NAME = "car-info-queue";
 	public static final String GPS_QUEUE_NAME = "gps-queue";
 	public static final String ONOFF_QUEUE_NAME = "on-off-Queue";
-	// public static final String OFF_QUEUE_NAME = "off-queue";
 
 	@Bean
 	public TopicExchange exchange() {
 		return new TopicExchange(EXCHANGE_NAME);
 	}
-
-	@Bean
-	public Queue gpsQueue() {
-		return new Queue(GPS_QUEUE_NAME, true);
-	}
-
-	@Bean
-	public Queue onOffQueue() {
-		return new Queue(ONOFF_QUEUE_NAME, true);
-	}
-
-	// @Bean
-	// public Queue offQueue() {
-	// 	return new Queue(OFF_QUEUE_NAME, true);
-	// }
-
-	@Bean
-	public Binding gpsBinding(Queue gpsQueue, TopicExchange exchange) {
-		return BindingBuilder.bind(gpsQueue).to(exchange).with("gps");
-	}
-
-	@Bean
-	public Binding onOffBinding(Queue onOffQueue, TopicExchange exchange) {
-		return BindingBuilder.bind(onOffQueue).to(exchange).with("on");
-	}
-
-	// @Bean
-	// public Binding offBinding(Queue offQueue, TopicExchange exchange) {
-	// 	return BindingBuilder.bind(offQueue).to(exchange).with("off");
-	// }
-
-	// @Bean
-	// public Queue queue() {
-	// 	return new Queue(QUEUE_NAME, true);
-	// }
-
-	// @Bean
-	// public Binding binding(Queue queue, TopicExchange exchange) {
-	// 	return BindingBuilder.bind(queue).to(exchange).with("#");
-	// }
 
 	@Bean
 	public Jackson2JsonMessageConverter messageConverter() {

--- a/tracky-hub/src/main/resources/application.yml
+++ b/tracky-hub/src/main/resources/application.yml
@@ -1,7 +1,8 @@
 spring:
   config:
     import: classpath:application-common.yml
-
+  profiles:
+    include: rabbitmq
   application:
     name: tracky-hub
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#148 

## 📝작업 내용

- HUB, CONSUMER RabbitMQConfig - 각 모듈 필요한 Bean만 주입받도록 변경
  - HUB: exchange, 메시지 컨버터, rabbitTemplate
  - CONSUMER: exchange, 메시지 컨버터, 큐, 바인딩

- HUB, CONSUMER만 RabbitMQ 연결하도록 변경
  - core 모듈의 applications-common.yml에 rabbitmq 설정이 있어서 web, emulator 모듈도 rabbitmq 연결되는 문제 있었음
  - hub, consumer 모듈만 rabbitmq 연결하도록 applications.yml 변경

## 💬리뷰 요구사항(선택)

- 태클 부탁드립니다.