### PR TITLE
#160 core에 vo 추가 및 에뮬레이터 vo 사용 리팩토링

### DIFF
--- a/tracky-core/src/main/java/kernel360/trackycore/core/common/entity/vo/EmulatorInfo.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/common/entity/vo/EmulatorInfo.java
@@ -1,0 +1,26 @@
+package kernel360.trackycore.core.common.entity.vo;
+
+import lombok.Getter;
+
+@Getter
+public class EmulatorInfo {
+	private final String mdn;    // 차량 식별 Key
+	private final String tid;    // 터미널 아이디 - 'A001'로 고정
+	private final String mid;    // 제조사 아이디 - CNSLink는 '6' 값 사용
+	private final String pv;     // 패킷 버전 - '5' 고정
+	private final String did;    // 디바이스 아이디 - GPS로만 운영함으로 '1'로 고정
+	private final String gcd;    // GPS 상태 - 'A' 고정
+
+	private EmulatorInfo(String mdn, String tid, String mid, String pv, String did, String gcd) {
+		this.mdn = mdn;
+		this.tid = tid;
+		this.mid = mid;
+		this.pv = pv;
+		this.did = did;
+		this.gcd = gcd;
+	}
+
+	public static EmulatorInfo create(String mdn) {
+		return new EmulatorInfo(mdn, "A001", "6", "5", "1", "A");
+	}
+}

--- a/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/CarInstanceFactory/MultiCarInstanceFactory.java
+++ b/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/CarInstanceFactory/MultiCarInstanceFactory.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import org.springframework.stereotype.Component;
 
+import kernel360.trackycore.core.common.entity.vo.EmulatorInfo;
 import kernel360.trackyemulator.application.service.util.RandomLocationGenerator;
 import kernel360.trackyemulator.domain.EmulatorInstance;
 import lombok.RequiredArgsConstructor;
@@ -40,9 +41,8 @@ public class MultiCarInstanceFactory {
 			int lon = locationGenerator.randomLongitude();
 			int ang = locationGenerator.randomAngle();
 
-			EmulatorInstance car = EmulatorInstance.create(
-				mdn, "A001", "6", "5", "1", "A", lat, lon, LocalDateTime.now(), ang
-			);
+			EmulatorInfo emulatorInfo = EmulatorInfo.create(mdn);
+			EmulatorInstance car = EmulatorInstance.create(emulatorInfo, lat, lon, LocalDateTime.now(), ang);
 
 			instances.add(car);
 		}

--- a/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/CarInstanceFactory/SingleCarInstanceFactory.java
+++ b/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/CarInstanceFactory/SingleCarInstanceFactory.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import kernel360.trackycore.core.common.entity.vo.EmulatorInfo;
 import kernel360.trackyemulator.application.service.util.RandomLocationGenerator;
 import kernel360.trackyemulator.domain.EmulatorInstance;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +23,11 @@ public class SingleCarInstanceFactory {
 		int lon = locationGenerator.randomLongitude();
 		int ang = locationGenerator.randomAngle();
 
-		EmulatorInstance car = EmulatorInstance.create(mdn, "A001", "6", "5", "1", "A", lat, lon, LocalDateTime.now(),
-			ang);
+		EmulatorInfo emulatorInfo = EmulatorInfo.create(mdn);
+		EmulatorInstance car = EmulatorInstance.create(emulatorInfo, lat, lon, LocalDateTime.now(), ang);
 
 		List<EmulatorInstance> instances = new ArrayList<>();
 		instances.add(car);
 		return instances;
 	}
-
 }

--- a/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/CarInstanceManager.java
+++ b/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/CarInstanceManager.java
@@ -65,8 +65,8 @@ public class CarInstanceManager {
 			String token = tokenRequestClient.getToken(instance);
 			instance.setToken(token);
 
-			result.put(instance.getMdn(), "토큰 세팅 성공" + instance.getToken());
-			log.info("{} 토큰 세팅 완료", instance.getMdn());
+			result.put(instance.getEmulatorInfo().getMdn(), "토큰 세팅 성공" + instance.getToken());
+			log.info("{} 토큰 세팅 완료", instance.getEmulatorInfo().getMdn());
 		}
 		return result;
 	}
@@ -77,7 +77,7 @@ public class CarInstanceManager {
 
 		for (EmulatorInstance instance : instances) {
 			ApiResponse response = startRequestClient.sendCarStart(instance);
-			result.put(instance.getMdn(), response.getRstMsg());
+			result.put(instance.getEmulatorInfo().getMdn(), response.getRstMsg());
 
 			cycleDataManager.startSending(instance); // 스케줄 시작
 		}
@@ -99,7 +99,7 @@ public class CarInstanceManager {
 			ApiResponse response = stopRequestClient.sendCarStop(instance);    //시동OFF 데이터 전송
 			log.info("시동 off response : {}", response.getRstMsg());
 
-			result.put(instance.getMdn(), response.getRstMsg());
+			result.put(instance.getEmulatorInfo().getMdn(), response.getRstMsg());
 
 			stoppedMdnSet.add(response.getMdn());
 		}
@@ -109,7 +109,7 @@ public class CarInstanceManager {
 
 	//에뮬레이터 삭제
 	private void removeStoppedInstances(Set<String> stoppedMdns) {
-		instances.removeIf(instance -> stoppedMdns.contains(instance.getMdn()));
+		instances.removeIf(instance -> stoppedMdns.contains(instance.getEmulatorInfo().getMdn()));
 		stoppedMdns.forEach(mdn -> log.info("{} 인스턴스 삭제 완료", mdn));
 	}
 

--- a/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/client/CycleRequestClient.java
+++ b/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/client/CycleRequestClient.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import kernel360.trackycore.core.common.entity.vo.EmulatorInfo;
 import kernel360.trackyemulator.domain.EmulatorInstance;
 import kernel360.trackyemulator.infrastructure.dto.ApiResponse;
 import kernel360.trackyemulator.infrastructure.dto.CycleGpsRequest;
@@ -29,12 +30,11 @@ public class CycleRequestClient {
 
 		// CycleInfoRequest DTO 생성
 		List<CycleGpsRequest> buffer = new ArrayList<>(instance.getCycleBuffer());
+
+		EmulatorInfo emulatorInfo = instance.getEmulatorInfo();
+
 		CycleInfoRequest request = CycleInfoRequest.of(
-			instance.getMdn(),
-			instance.getTid(),
-			instance.getMid(),
-			instance.getPv(),
-			instance.getDid(),
+			emulatorInfo,
 			LocalDateTime.now(),
 			buffer
 		);
@@ -55,10 +55,10 @@ public class CycleRequestClient {
 		ApiResponse apiResponse = response.getBody();
 		if (apiResponse == null || !("000".equals(apiResponse.getRstCd()))) {
 			throw new IllegalStateException(
-				"주기 데이터 전송 실패 " + request.getMdn());
+				"주기 데이터 전송 실패 " + request.getEmulatorInfo().getMdn());
 		}
 
-		log.info("{} → 60초 주기 데이터 전송 완료", request.getMdn());
+		log.info("{} → 60초 주기 데이터 전송 완료", request.getEmulatorInfo().getMdn());
 
 		return apiResponse;
 	}

--- a/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/client/TokenRequestClient.java
+++ b/tracky-emulator/src/main/java/kernel360/trackyemulator/application/service/client/TokenRequestClient.java
@@ -21,7 +21,7 @@ public class TokenRequestClient {
 	public String getToken(EmulatorInstance instance) {
 
 		//TokenRequest DTO 생성
-		TokenRequest request = TokenRequest.from(instance);
+		TokenRequest request = TokenRequest.toRequest(instance);
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.setContentType(MediaType.APPLICATION_JSON);
@@ -39,7 +39,7 @@ public class TokenRequestClient {
 		ApiResponse apiResponse = response.getBody();
 		if (apiResponse == null || !("000".equals(apiResponse.getRstCd()))) {
 			throw new IllegalStateException(
-				"토큰 요청 실패 " + instance.getMdn());
+				"토큰 요청 실패 " + instance.getEmulatorInfo().getMdn());
 		}
 
 		return apiResponse.getToken();

--- a/tracky-emulator/src/main/java/kernel360/trackyemulator/domain/EmulatorInstance.java
+++ b/tracky-emulator/src/main/java/kernel360/trackyemulator/domain/EmulatorInstance.java
@@ -4,18 +4,14 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import kernel360.trackycore.core.common.entity.vo.EmulatorInfo;
 import kernel360.trackyemulator.infrastructure.dto.CycleGpsRequest;
 import lombok.Getter;
 
 @Getter
 public class EmulatorInstance {
 
-	private final String mdn;    // 차량 식별 Key
-	private final String tid;    // 터미널 아이디 - 'A001'로 고정
-	private final String mid;    // 제조사 아이디 - CNSLink는 '6' 값 사용
-	private final String pv;     // 패킷 버전 - '5' 고정
-	private final String did;    // 디바이스 아이디 - GPS로만 운영함으로 '1'로 고정
-	private final String gcd;    // GPS 상태 - 'A' 고정
+	private final EmulatorInfo emulatorInfo;
 
 	private String token;  // 단말 인증 토큰
 
@@ -31,14 +27,9 @@ public class EmulatorInstance {
 
 	private final List<CycleGpsRequest> cycleBuffer = new ArrayList<>();
 
-	private EmulatorInstance(String mdn, String tid, String mid, String pv, String did, String gcd, int cycleLastLat,
-		int cycleLastLon, LocalDateTime carOnTime, int ang) {
-		this.mdn = mdn;
-		this.tid = tid;
-		this.mid = mid;
-		this.pv = pv;
-		this.did = did;
-		this.gcd = gcd;
+	private EmulatorInstance(EmulatorInfo emulatorInfo, int cycleLastLat, int cycleLastLon, LocalDateTime carOnTime,
+		int ang) {
+		this.emulatorInfo = emulatorInfo;
 		this.sum = 0;
 		this.cycleLastLat = cycleLastLat;
 		this.cycleLastLon = cycleLastLon;
@@ -46,9 +37,9 @@ public class EmulatorInstance {
 		this.ang = ang;
 	}
 
-	public static EmulatorInstance create(String mdn, String tid, String mid, String pv, String did, String gcd,
-		int cycleLastLat, int cycleLastLon, LocalDateTime carOnTime, int ang) {
-		return new EmulatorInstance(mdn, tid, mid, pv, did, gcd, cycleLastLat, cycleLastLon, carOnTime, ang);
+	public static EmulatorInstance create(EmulatorInfo emulatorInfo, int cycleLastLat, int cycleLastLon,
+		LocalDateTime carOnTime, int ang) {
+		return new EmulatorInstance(emulatorInfo, cycleLastLat, cycleLastLon, carOnTime, ang);
 	}
 
 	//토큰 세팅

--- a/tracky-emulator/src/main/java/kernel360/trackyemulator/infrastructure/dto/CarOnOffRequest.java
+++ b/tracky-emulator/src/main/java/kernel360/trackyemulator/infrastructure/dto/CarOnOffRequest.java
@@ -4,17 +4,14 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import kernel360.trackycore.core.common.entity.vo.EmulatorInfo;
 import kernel360.trackyemulator.domain.EmulatorInstance;
 import lombok.Getter;
 
 @Getter
 public class CarOnOffRequest {
 
-	private String mdn;
-	private String tid;
-	private String mid;
-	private String pv;
-	private String did;
+	private EmulatorInfo emulatorInfo;
 
 	@JsonFormat(pattern = "yyyyMMddHHmm")
 	private LocalDateTime onTime;
@@ -28,14 +25,9 @@ public class CarOnOffRequest {
 	private int spd;
 	private double sum;
 
-	private CarOnOffRequest(String mdn, String tid, String mid, String pv, String did,
-		LocalDateTime onTime, LocalDateTime offTime,
-		String gcd, int lat, int lon, int ang, int spd, double sum) {
-		this.mdn = mdn;
-		this.tid = tid;
-		this.mid = mid;
-		this.pv = pv;
-		this.did = did;
+	private CarOnOffRequest(EmulatorInfo emulatorInfo, LocalDateTime onTime, LocalDateTime offTime, String gcd, int lat,
+		int lon, int ang, int spd, double sum) {
+		this.emulatorInfo = emulatorInfo;
 		this.onTime = onTime;
 		this.offTime = offTime;
 		this.gcd = gcd;
@@ -47,17 +39,13 @@ public class CarOnOffRequest {
 	}
 
 	/**
-	 * 시동 ON DTO 생성 (EmulatorInstance + Random 위치)
+	 * 시동 ON DTO 생성
 	 */
 	public static CarOnOffRequest ofOn(EmulatorInstance car) {
 		return new CarOnOffRequest(
-			car.getMdn(),
-			car.getTid(),
-			car.getMid(),
-			car.getPv(),
-			car.getDid(),
-			car.getCarOnTime(), // onTime
-			null,               // offTime
+			car.getEmulatorInfo(),
+			car.getCarOnTime(),
+			null,               // 시동 ON시 offTime은 null
 			"A",
 			car.getCycleLastLat(),
 			car.getCycleLastLon(),
@@ -72,13 +60,9 @@ public class CarOnOffRequest {
 	 */
 	public static CarOnOffRequest ofOff(EmulatorInstance car) {
 		return new CarOnOffRequest(
-			car.getMdn(),
-			car.getTid(),
-			car.getMid(),
-			car.getPv(),
-			car.getDid(),
-			car.getCarOnTime(),               // onTime
-			car.getCarOffTime(), // offTime
+			car.getEmulatorInfo(),
+			car.getCarOnTime(),
+			car.getCarOffTime(),
 			"A",
 			car.getCycleLastLat(),
 			car.getCycleLastLon(),

--- a/tracky-emulator/src/main/java/kernel360/trackyemulator/infrastructure/dto/CycleInfoRequest.java
+++ b/tracky-emulator/src/main/java/kernel360/trackyemulator/infrastructure/dto/CycleInfoRequest.java
@@ -6,16 +6,13 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import kernel360.trackycore.core.common.entity.vo.EmulatorInfo;
 import lombok.Getter;
 
 @Getter
 public class CycleInfoRequest {
 
-	private String mdn;    // 차량 번호
-	private String tid;    // 터미널 아이디
-	private String mid;    // 제조사 아이디
-	private String pv;     // 패킷 버전
-	private String did;    // 디바이스 아이디
+	private EmulatorInfo emulatorInfo;
 
 	@JsonProperty("cCnt")
 	private final int cCnt;   // 주기 정보 개수
@@ -26,26 +23,16 @@ public class CycleInfoRequest {
 	@JsonProperty("cList")
 	private final List<CycleGpsRequest> cList;  // 주기정보 리스트
 
-	private CycleInfoRequest(String mdn, String tid, String mid, String pv, String did,
-		int cCnt, LocalDateTime oTime, List<CycleGpsRequest> cList) {
-		this.mdn = mdn;
-		this.tid = tid;
-		this.mid = mid;
-		this.pv = pv;
-		this.did = did;
+	private CycleInfoRequest(EmulatorInfo emulatorInfo, int cCnt, LocalDateTime oTime, List<CycleGpsRequest> cList) {
+		this.emulatorInfo = emulatorInfo;
 		this.cCnt = cCnt;
 		this.oTime = oTime;
 		this.cList = cList;
 	}
 
-	public static CycleInfoRequest of(String mdn, String tid, String mid, String pv, String did,
-		LocalDateTime oTime, List<CycleGpsRequest> cList) {
+	public static CycleInfoRequest of(EmulatorInfo emulatorInfo, LocalDateTime oTime, List<CycleGpsRequest> cList) {
 		return new CycleInfoRequest(
-			mdn,
-			tid,
-			mid,
-			pv,
-			did,
+			emulatorInfo,
 			cList.size(),
 			oTime,
 			cList

--- a/tracky-emulator/src/main/java/kernel360/trackyemulator/infrastructure/dto/TokenRequest.java
+++ b/tracky-emulator/src/main/java/kernel360/trackyemulator/infrastructure/dto/TokenRequest.java
@@ -1,35 +1,24 @@
 package kernel360.trackyemulator.infrastructure.dto;
 
+import kernel360.trackycore.core.common.entity.vo.EmulatorInfo;
 import kernel360.trackyemulator.domain.EmulatorInstance;
 import lombok.Getter;
 
 @Getter
 public class TokenRequest {
 
-    private String mdn;    // 차량 번호
-    private String tid;    // 터미널 아이디
-    private String mid;    // 제조사 아이디
-    private String pv;     // 패킷 버전
-    private String did;    // 디바이스 아이디
+	private EmulatorInfo emulatorInfo;
 
-    private TokenRequest(String mdn, String tid, String mid, String pv, String did) {
-        this.mdn = mdn;
-        this.tid = tid;
-        this.mid = mid;
-        this.pv = pv;
-        this.did = did;
-    }
+	private TokenRequest(EmulatorInfo emulatorInfo) {
+		this.emulatorInfo = emulatorInfo;
+	}
 
-    /**
-     * EmulatorInstance 기반 TokenRequest 생성
-     */
-    public static TokenRequest from(EmulatorInstance car) {
-        return new TokenRequest(
-                car.getMdn(),
-                car.getTid(),
-                car.getMid(),
-                car.getPv(),
-                car.getDid()
-        );
-    }
+	/**
+	 * EmulatorInstance 기반 TokenRequest 생성
+	 */
+	public static TokenRequest toRequest(EmulatorInstance car) {
+		return new TokenRequest(
+			car.getEmulatorInfo()
+		);
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#160 

## 📝작업 내용

1. core 모듈(common-entity-vo-EmulatorInfo)에  에뮬레이터 공통정보 vo 추가했습니다.
2. 에뮬레이터 모듈에서 해당 vo를 사용하는 것으로 코드 리팩토링 했습니다.

- 보통 vo는 @Override로 equals(), hashCode()를 구현한다고 합니다. 하지만 저희 로직상 필요하지 않을 것 같아서 지금은 추가하지 않았습니다. 추후에 논의해보면 좋을 것 같습니다.
-