### PR TITLE
WEB, CONSUMER - 핸들링 하지 않는 에러 디스코드로 알림 전송

### DIFF
--- a/tracky-consumer/src/main/java/kernel360/trackyconsumer/common/exception/ConsumerGlobalExceptionHandler.java
+++ b/tracky-consumer/src/main/java/kernel360/trackyconsumer/common/exception/ConsumerGlobalExceptionHandler.java
@@ -4,12 +4,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import kernel360.trackycore.core.common.webhook.Notifier;
+import lombok.RequiredArgsConstructor;
+
 @RestControllerAdvice
 @io.swagger.v3.oas.annotations.Hidden
+@RequiredArgsConstructor
 public class ConsumerGlobalExceptionHandler {
+	private final Notifier notifier;
 
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ErrorResponse> handleException(Exception e) {
+		notifier.notify(e);
 		return ResponseEntity
 			.internalServerError()
 			.body(ErrorResponse.from(e));

--- a/tracky-consumer/src/main/resources/application.yml
+++ b/tracky-consumer/src/main/resources/application.yml
@@ -17,3 +17,6 @@ rabbitmq:
 
 server:
   port: 8083
+
+discord:
+  webhook-url: ${DISCORD_WEBHOOK_CONSUMER_URL}

--- a/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/Notifier.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/Notifier.java
@@ -1,0 +1,5 @@
+package kernel360.trackycore.core.common.webhook;
+
+public interface Notifier {
+	void notify(Exception e);
+}

--- a/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordMessage.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordMessage.java
@@ -1,0 +1,8 @@
+package kernel360.trackycore.core.common.webhook.discord;
+
+import java.util.List;
+
+public record DiscordMessage(List<Embed> embeds) {
+	public record Embed(String title, String description) {
+	}
+}

--- a/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordNotifier.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordNotifier.java
@@ -1,9 +1,8 @@
 package kernel360.trackycore.core.common.webhook.discord;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.List;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -33,12 +32,7 @@ public class DiscordNotifier implements Notifier {
 	}
 
 	private DiscordMessage createMessage(Exception e) {
-		String stackTrace = getStackTrace(e);
-
-		// 디스코드 메시지 제한때문에 max 값 설정
-		if (stackTrace.length() > 2000) {
-			stackTrace = stackTrace.substring(0, 2000) + "\n... (생략)";
-		}
+		String stackTrace = cutStackTrace(e);
 
 		return new DiscordMessage(
 			List.of(
@@ -48,9 +42,17 @@ public class DiscordNotifier implements Notifier {
 		);
 	}
 
-	private String getStackTrace(Exception e) {
-		StringWriter stringWriter = new StringWriter();
-		e.printStackTrace(new PrintWriter(stringWriter));
-		return stringWriter.toString();
+	private String cutStackTrace(Exception e) {
+		String stackTrace = ExceptionUtils.getStackTrace(e);
+
+		if (isTooLongMessage(stackTrace)) {
+			stackTrace = stackTrace.substring(0, 2000) + "\n... (생략)";
+		}
+
+		return stackTrace;
+	}
+
+	private boolean isTooLongMessage(String stackTrace) {
+		return stackTrace.length() > 2000;
 	}
 }

--- a/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordNotifier.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordNotifier.java
@@ -1,0 +1,56 @@
+package kernel360.trackycore.core.common.webhook.discord;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import kernel360.trackycore.core.common.webhook.Notifier;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@ConditionalOnExpression("'${discord.webhook‑url}'.length() > 0")
+public class DiscordNotifier implements Notifier {
+	private final RestClient restClient;
+
+	public DiscordNotifier(DiscordProperties discordProperties) {
+		restClient = RestClient.create(discordProperties.getWebhookUrl());
+	}
+
+	@Override
+	public void notify(Exception e) {
+		var a = restClient.post()
+			.contentType(MediaType.APPLICATION_JSON)
+			.body(createMessage(e))
+			.retrieve()
+			.body(String.class);
+		log.info("Discord notification sent: {}", a);
+	}
+
+	private DiscordMessage createMessage(Exception e) {
+		String stackTrace = getStackTrace(e);
+
+		// 디스코드 메시지 제한때문에 max 값 설정
+		if (stackTrace.length() > 2000) {
+			stackTrace = stackTrace.substring(0, 2000) + "\n... (생략)";
+		}
+
+		return new DiscordMessage(
+			List.of(
+				new DiscordMessage.Embed("ℹ️ 에러 요약", "```" + e.getMessage() + "```"),
+				new DiscordMessage.Embed("📄 Stack Trace\n", "```" + stackTrace + "```")
+			)
+		);
+	}
+
+	private String getStackTrace(Exception e) {
+		StringWriter stringWriter = new StringWriter();
+		e.printStackTrace(new PrintWriter(stringWriter));
+		return stringWriter.toString();
+	}
+}

--- a/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordProperties.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordProperties.java
@@ -1,0 +1,15 @@
+package kernel360.trackycore.core.common.webhook.discord;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Configuration
+@ConfigurationProperties(prefix = "discord")
+@Getter
+@Setter
+public class DiscordProperties {
+	private String webhookUrl;
+}

--- a/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/local/LocalNotifier.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/local/LocalNotifier.java
@@ -1,0 +1,18 @@
+package kernel360.trackycore.core.common.webhook.local;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+import kernel360.trackycore.core.common.webhook.Notifier;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@ConditionalOnExpression("'${discord.webhook‑url}'.length() == 0")
+public class LocalNotifier implements Notifier {
+
+	@Override
+	public void notify(Exception e) {
+		log.info("Local notification: {}", e.getMessage());
+	}
+}

--- a/tracky-web/src/main/java/kernel360/trackyweb/common/exception/WebGlobalExceptionHandler.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/common/exception/WebGlobalExceptionHandler.java
@@ -1,19 +1,37 @@
 package kernel360.trackyweb.common.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import kernel360.trackycore.core.common.exception.GlobalException;
+import kernel360.trackycore.core.common.webhook.Notifier;
+import lombok.RequiredArgsConstructor;
 
 @RestControllerAdvice
-@io.swagger.v3.oas.annotations.Hidden
+@RequiredArgsConstructor
 public class WebGlobalExceptionHandler {
+	private final Notifier notifier;
 
 	@ExceptionHandler(GlobalException.class)
 	public ResponseEntity<ErrorResponse> handleWebGlobalException(GlobalException e) {
 		return ResponseEntity
 			.badRequest()
 			.body(ErrorResponse.from(e));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorResponse> handleWebGlobalException(Exception e) {
+		notifier.notify(e);
+
+		ErrorResponse errorResponse = new ErrorResponse(
+			String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR.value()),
+			e.getMessage()
+		);
+
+		return ResponseEntity
+			.internalServerError()
+			.body(errorResponse);
 	}
 }

--- a/tracky-web/src/main/resources/application.yml
+++ b/tracky-web/src/main/resources/application.yml
@@ -18,3 +18,6 @@ spring:
     level:
       org.hibernate.SQL: debug            # SQL 쿼리
       org.hibernate.type.descriptor.sql: trace   # 파라미터 값까지 출력
+
+discord:
+  webhook-url: ${DISCORD_WEBHOOK_WEB_URL}


### PR DESCRIPTION
## #️⃣연관된 이슈

closed #216 

## 📝작업 내용

.env 파일에 
DISCORD_WEBHOOK_CONSUMER_URL=...url...
DISCORD_WEBHOOK_WEB_URL=...url...

위와 같은 정보가 있으면 discord로 에러 알림을 전송합니다.
로컬에서는 넣지 말고 사용해주세요.

배포 환경에만 웹훅 주소 넣으면 됩니다.
같이세팅하시지요..