### PR TITLE
Hotfix - LocalNotifier가 제대로 작동하지 않던 문제

### DIFF
--- a/tracky-consumer/src/main/resources/application.yml
+++ b/tracky-consumer/src/main/resources/application.yml
@@ -19,4 +19,5 @@ server:
   port: 8083
 
 discord:
-  webhook-url: ${DISCORD_WEBHOOK_CONSUMER_URL}
+  enable: ${DISCORD_WEBHOOK_ENABLE:false}
+  webhook-url: ${DISCORD_WEBHOOK_WEB_URL}

--- a/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordNotifier.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/discord/DiscordNotifier.java
@@ -3,7 +3,7 @@ package kernel360.trackycore.core.common.webhook.discord;
 import java.util.List;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -13,7 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@ConditionalOnExpression("'${discord.webhook‑url}'.length() > 0")
+@ConditionalOnProperty(prefix = "discord", name = "enable", havingValue = "true")
 public class DiscordNotifier implements Notifier {
 	private final RestClient restClient;
 

--- a/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/local/LocalNotifier.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/common/webhook/local/LocalNotifier.java
@@ -1,6 +1,6 @@
 package kernel360.trackycore.core.common.webhook.local;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import kernel360.trackycore.core.common.webhook.Notifier;
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
-@ConditionalOnExpression("'${discord.webhook‑url}'.length() == 0")
+@ConditionalOnProperty(prefix = "discord", name = "enable", havingValue = "false")
 public class LocalNotifier implements Notifier {
 
 	@Override

--- a/tracky-web/src/main/resources/application.yml
+++ b/tracky-web/src/main/resources/application.yml
@@ -20,4 +20,5 @@ spring:
       org.hibernate.type.descriptor.sql: trace   # 파라미터 값까지 출력
 
 discord:
+  enable: ${DISCORD_WEBHOOK_ENABLE:false}
   webhook-url: ${DISCORD_WEBHOOK_WEB_URL}


### PR DESCRIPTION
DiscorWebhook를 사용하지 않는다면 LocalNotifier가 주입되어야 하는데, 제대로 작동하지 않아 수정했습니다.