### PR TITLE
CORE - 커넥션 풀 설정 추가, 주기정보 save 로직 수정

### DIFF
--- a/tracky-core/src/main/java/kernel360/trackycore/core/domain/provider/GpsHistoryProvider.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/domain/provider/GpsHistoryProvider.java
@@ -1,5 +1,7 @@
 package kernel360.trackycore.core.domain.provider;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import kernel360.trackycore.core.domain.entity.GpsHistoryEntity;
@@ -14,5 +16,9 @@ public class GpsHistoryProvider {
 
 	public GpsHistoryEntity save(GpsHistoryEntity gpsHistory) {
 		return gpsHistoryRepository.save(gpsHistory);
+	}
+
+	public void saveAll(List<GpsHistoryEntity> gpsHistoryList) {
+		gpsHistoryRepository.saveAll(gpsHistoryList);
 	}
 }

--- a/tracky-core/src/main/resources/application-common.yml
+++ b/tracky-core/src/main/resources/application-common.yml
@@ -7,11 +7,19 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      pool-name: ConsumerHikariCP
+      maximum-pool-size: 60
+      minimum-idle: 10
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 600000
+      leak-detection-threshold: 10000
 
   jpa:
     hibernate:
       ddl-auto: none
-    database-platform: org.hibernate.dialect.MySQLDialect
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     properties:
       hibernate.globally_quoted_identifiers: true
       hibernate.format_sql: true
@@ -30,6 +38,3 @@ management:
     web:
       exposure:
         include: prometheus
-  endpoint:
-    prometheus:
-      enabled: true


### PR DESCRIPTION
## #️⃣연관된 이슈

> #225 

## 📝작업 내용

> application-common.yml 에 커넥션풀 관련 설정을 추가
> Consumer 모듈에서 주기정보를 save하는 로직을 List로 한번에 saveAll() 하는 방식으로 변경했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
