### PR TITLE
WEB - GpsHistory sec 필드 제거 및 oTime에 sec 저장

### DIFF
--- a/tracky-consumer/src/main/java/kernel360/trackyconsumer/consumer/application/dto/request/CycleGpsRequest.java
+++ b/tracky-consumer/src/main/java/kernel360/trackyconsumer/consumer/application/dto/request/CycleGpsRequest.java
@@ -10,13 +10,11 @@ import kernel360.trackycore.core.domain.entity.GpsHistoryEntity;
 import kernel360.trackycore.core.domain.vo.GpsInfo;
 
 public record CycleGpsRequest(
-	int sec,
 	String gcd,
 	GpsInfo gpsInfo
 ) {
 	@JsonCreator
 	public CycleGpsRequest(
-		@JsonProperty int sec,
 		@JsonProperty String gcd,
 		@JsonProperty int lat,
 		@JsonProperty int lon,
@@ -24,11 +22,11 @@ public record CycleGpsRequest(
 		@JsonProperty int spd,
 		@JsonProperty double sum
 	) {
-		this(sec, gcd, GpsInfo.create(lat, lon, ang, spd, sum));
+		this(gcd, GpsInfo.create(lat, lon, ang, spd, sum));
 	}
 
 	public GpsHistoryEntity toGpsHistoryEntity(DriveEntity drive, LocalDateTime oTime, double sum) {
-		return new GpsHistoryEntity(drive, oTime, this.sec, this.gcd, this.gpsInfo.getLat(), this.gpsInfo.getLon(),
+		return new GpsHistoryEntity(drive, oTime, this.gcd, this.gpsInfo.getLat(), this.gpsInfo.getLon(),
 			this.gpsInfo.getAng(), this.gpsInfo.getSpd(), sum);
 	}
 }

--- a/tracky-consumer/src/main/java/kernel360/trackyconsumer/consumer/application/dto/request/CycleInfoRequest.java
+++ b/tracky-consumer/src/main/java/kernel360/trackyconsumer/consumer/application/dto/request/CycleInfoRequest.java
@@ -27,7 +27,7 @@ public record CycleInfoRequest(
 		@JsonProperty String did,
 		@JsonProperty String mdn,
 		@JsonProperty int cCnt,
-		@JsonProperty @JsonFormat(pattern = "yyyyMMddHHmm") LocalDateTime oTime,
+		@JsonProperty @JsonFormat(pattern = "yyyyMMddHHmmss") LocalDateTime oTime,
 		@JsonProperty List<CycleGpsRequest> cList
 	) {
 		this(EmulatorInfo.create(tid, mid, pv, did), mdn, cCnt, oTime, cList);

--- a/tracky-consumer/src/main/java/kernel360/trackyconsumer/consumer/application/dto/request/GpsHistoryMessage.java
+++ b/tracky-consumer/src/main/java/kernel360/trackyconsumer/consumer/application/dto/request/GpsHistoryMessage.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 public record GpsHistoryMessage(
 	String mdn,
 
-	@JsonFormat(pattern = "yyyyMMddHHmm")
+	@JsonFormat(pattern = "yyyyMMddHHmmss")
 	LocalDateTime oTime,
 
 	int cCnt,

--- a/tracky-core/src/main/java/kernel360/trackycore/core/domain/entity/GpsHistoryEntity.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/domain/entity/GpsHistoryEntity.java
@@ -65,7 +65,7 @@ public class GpsHistoryEntity {
 		}
 	}
 
-	public GpsHistoryEntity(DriveEntity drive, LocalDateTime oTime, int sec, String gcd, int lat, int lon, int ang,
+	public GpsHistoryEntity(DriveEntity drive, LocalDateTime oTime, String gcd, int lat, int lon, int ang,
 		int spd,
 		double sum) {
 		this.drive = drive;

--- a/tracky-hub/src/main/java/kernel360trackybe/trackyhub/application/dto/request/CycleGpsRequest.java
+++ b/tracky-hub/src/main/java/kernel360trackybe/trackyhub/application/dto/request/CycleGpsRequest.java
@@ -5,11 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import kernel360.trackycore.core.domain.vo.GpsInfo;
 
-public record CycleGpsRequest(int sec, String gcd, GpsInfo gpsInfo) {
+public record CycleGpsRequest(String gcd, GpsInfo gpsInfo) {
 
 	@JsonCreator
 	public CycleGpsRequest(
-		@JsonProperty int sec,
 		@JsonProperty String gcd,
 		@JsonProperty int lat,
 		@JsonProperty int lon,
@@ -17,6 +16,6 @@ public record CycleGpsRequest(int sec, String gcd, GpsInfo gpsInfo) {
 		@JsonProperty int spd,
 		@JsonProperty double sum
 	) {
-		this(sec, gcd, GpsInfo.create(lat, lon, ang, spd, sum));
+		this(gcd, GpsInfo.create(lat, lon, ang, spd, sum));
 	}
 }

--- a/tracky-hub/src/main/java/kernel360trackybe/trackyhub/application/dto/request/CycleInfoRequest.java
+++ b/tracky-hub/src/main/java/kernel360trackybe/trackyhub/application/dto/request/CycleInfoRequest.java
@@ -20,7 +20,7 @@ public record CycleInfoRequest(String mdn, EmulatorInfo emulatorInfo, int cCnt, 
 		@JsonProperty String did,
 		@JsonProperty String pv,
 		@JsonProperty int cCnt,
-		@JsonProperty @JsonFormat(pattern = "yyyyMMddHHmm") LocalDateTime oTime,
+		@JsonProperty @JsonFormat(pattern = "yyyyMMddHHmmss") LocalDateTime oTime,
 		@JsonProperty List<CycleGpsRequest> cList
 	) {
 		this(mdn, EmulatorInfo.create(tid, mid, did, pv), cCnt, oTime, cList);

--- a/tracky-hub/src/main/java/kernel360trackybe/trackyhub/application/dto/request/GpsHistoryMessage.java
+++ b/tracky-hub/src/main/java/kernel360trackybe/trackyhub/application/dto/request/GpsHistoryMessage.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 public record GpsHistoryMessage(String mdn, LocalDateTime oTime, int cCnt,
 								List<CycleGpsRequest> cList) {
 
-	public GpsHistoryMessage(String mdn, @JsonFormat(pattern = "yyyyMMddHHmm") LocalDateTime oTime, int cCnt,
+	public GpsHistoryMessage(String mdn, @JsonFormat(pattern = "yyyyMMddHHmmss") LocalDateTime oTime, int cCnt,
 		List<CycleGpsRequest> cList) {
 		this.mdn = mdn;
 		this.oTime = oTime;


### PR DESCRIPTION
## #️⃣연관된 이슈

#249

## 📝작업 내용

- GpsHistory 엔티티 필드 변경
  - sec 필드 제거
  - oTime 필드에 초까지 저장("yyyyMMddHHmmss")

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 잘 부탁드립니다!
