### PR TITLE
CORE, CUNSUMER  - 주기 정보 메시지 역직렬화 문제 해결

### DIFF
--- a/tracky-consumer/src/main/java/kernel360/trackyconsumer/consumer/application/dto/request/CycleGpsRequest.java
+++ b/tracky-consumer/src/main/java/kernel360/trackyconsumer/consumer/application/dto/request/CycleGpsRequest.java
@@ -14,15 +14,11 @@ public record CycleGpsRequest(
 	GpsInfo gpsInfo
 ) {
 	@JsonCreator
-	public CycleGpsRequest(
-		@JsonProperty String gcd,
-		@JsonProperty int lat,
-		@JsonProperty int lon,
-		@JsonProperty int ang,
-		@JsonProperty int spd,
-		@JsonProperty double sum
+	public static CycleGpsRequest create(
+			@JsonProperty("gcd") String gcd,
+			@JsonProperty("gpsInfo") GpsInfo gpsInfo
 	) {
-		this(gcd, GpsInfo.create(lat, lon, ang, spd, sum));
+		return new CycleGpsRequest(gcd, gpsInfo);
 	}
 
 	public GpsHistoryEntity toGpsHistoryEntity(DriveEntity drive, LocalDateTime oTime, double sum) {

--- a/tracky-core/src/main/java/kernel360/trackycore/core/domain/vo/GpsInfo.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/domain/vo/GpsInfo.java
@@ -1,8 +1,12 @@
 package kernel360.trackycore.core.domain.vo;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class GpsInfo {
 	private final int lat;
 	private final int lon;
@@ -10,7 +14,14 @@ public class GpsInfo {
 	private final int spd;
 	private final double sum;
 
-	private GpsInfo(int lat, int lon, int ang, int spd, double sum) {
+	@JsonCreator
+	private GpsInfo(
+			@JsonProperty("lat") int lat,
+			@JsonProperty("lon") int lon,
+			@JsonProperty("ang") int ang,
+			@JsonProperty("spd") int spd,
+			@JsonProperty("sum") double sum
+	) {
 		this.lat = lat;
 		this.lon = lon;
 		this.ang = ang;


### PR DESCRIPTION
## #️⃣연관된 이슈

#251

## 📝작업 내용

- Hub는 GpsInfo VO를 평면화하지 않고 객체 그대로 보내지만 Consumer는 평면화해서 받도록 되어 있었음.
  - Consumer에서 GpsInfo 객체를 그대로 받도록 변경하여 역직렬화 문제 해결

자세한 내용은 이슈 확인해주세요.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

- 굿~
