### PR TITLE
WEB - 실시간 추적용 web-queue 추가

### DIFF
--- a/tracky-web/build.gradle
+++ b/tracky-web/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
     implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 
     implementation 'org.locationtech.jts:jts-core:1.18.2'

--- a/tracky-web/src/main/java/kernel360/trackyweb/common/config/RabbitMQConfig.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/common/config/RabbitMQConfig.java
@@ -1,0 +1,43 @@
+package kernel360.trackyweb.common.config;
+
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class RabbitMQConfig {
+
+	private final RabbitMQProperties properties;
+
+	@Bean
+	public Jackson2JsonMessageConverter messageConverter() {
+		return new Jackson2JsonMessageConverter();
+	}
+
+	@Bean
+	public SimpleRabbitListenerContainerFactory batchRabbitListenerContainerFactory(
+		ConnectionFactory connectionFactory) {
+		SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+		factory.setConnectionFactory(connectionFactory);
+		factory.setBatchSize(properties.getBatch().getSize());
+		factory.setReceiveTimeout(properties.getBatch().getTimeout());
+		factory.setBatchListener(properties.getBatch().isEnabled());
+		factory.setConsumerBatchEnabled(properties.getBatch().isConsumerBatchEnabled());
+		factory.setMessageConverter(messageConverter());
+
+		factory.setErrorHandler(throwable -> {
+			log.error("배치 처리 중 오류 발생: {}", throwable.getMessage());
+		});
+
+		factory.setDefaultRequeueRejected(properties.getBatch().isDefaultRequeueRejected());
+
+		return factory;
+	}
+}

--- a/tracky-web/src/main/java/kernel360/trackyweb/common/config/RabbitMQProperties.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/common/config/RabbitMQProperties.java
@@ -1,0 +1,26 @@
+package kernel360.trackyweb.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Configuration
+@ConfigurationProperties(prefix = "rabbitmq")
+@Getter
+@Setter
+public class RabbitMQProperties {
+
+	private Batch batch;
+
+	@Getter
+	@Setter
+	public static class Batch {
+		private boolean defaultRequeueRejected;
+		private boolean enabled;
+		private int size;
+		private long timeout;
+		private boolean consumerBatchEnabled;
+	}
+}

--- a/tracky-web/src/main/java/kernel360/trackyweb/realtime/application/dto/request/CycleGpsRequest.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/realtime/application/dto/request/CycleGpsRequest.java
@@ -1,0 +1,31 @@
+package kernel360.trackyweb.realtime.application.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import kernel360.trackycore.core.domain.entity.DriveEntity;
+import kernel360.trackycore.core.domain.entity.GpsHistoryEntity;
+import kernel360.trackycore.core.domain.vo.GpsInfo;
+
+public record CycleGpsRequest(
+	LocalDateTime oTime,
+	String gcd,
+	GpsInfo gpsInfo
+) {
+	@JsonCreator
+	public static CycleGpsRequest create(
+		@JsonProperty @JsonFormat(pattern = "yyyyMMddHHmmss") LocalDateTime oTime,
+		@JsonProperty("gcd") String gcd,
+		@JsonProperty("gpsInfo") GpsInfo gpsInfo
+	) {
+		return new CycleGpsRequest(oTime, gcd, gpsInfo);
+	}
+
+	public GpsHistoryEntity toGpsHistoryEntity(DriveEntity drive, double sum) {
+		return new GpsHistoryEntity(drive, this.oTime, this.gcd, this.gpsInfo.getLat(), this.gpsInfo.getLon(),
+			this.gpsInfo.getAng(), this.gpsInfo.getSpd(), sum);
+	}
+}

--- a/tracky-web/src/main/java/kernel360/trackyweb/realtime/application/dto/request/GpsHistoryMessage.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/realtime/application/dto/request/GpsHistoryMessage.java
@@ -1,0 +1,18 @@
+package kernel360.trackyweb.realtime.application.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public record GpsHistoryMessage(
+	String mdn,
+
+	@JsonFormat(pattern = "yyyyMMddHHmmss")
+	LocalDateTime oTime,
+
+	int cCnt,
+
+	List<CycleGpsRequest> cList
+) {
+}

--- a/tracky-web/src/main/java/kernel360/trackyweb/realtime/application/service/MessageListener.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/realtime/application/service/MessageListener.java
@@ -1,0 +1,26 @@
+package kernel360.trackyweb.realtime.application.service;
+
+import java.util.List;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+
+import kernel360.trackyweb.realtime.application.dto.request.GpsHistoryMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MessageListener {
+
+	// GPS 정보 처리 큐
+	@RabbitListener(queues = "web-queue", containerFactory = "batchRabbitListenerContainerFactory")
+	public void receiveCarMessages(List<GpsHistoryMessage> messages) {
+		log.info("GPS 메시지 배치 수신: {} 개", messages.size());
+
+		messages.forEach(message -> {
+			log.info("GPS 메시지 수신: {}", message.toString());
+		});
+	}
+}

--- a/tracky-web/src/main/resources/application.yml
+++ b/tracky-web/src/main/resources/application.yml
@@ -3,7 +3,9 @@ server:
 
 spring:
   config:
-    import: classpath:application-common.yml
+    import:
+      - classpath:application-common.yml
+      - classpath:application-rabbitmq.yml
 
   application:
     name: tracky-web
@@ -22,3 +24,12 @@ spring:
 discord:
   enable: ${DISCORD_WEBHOOK_ENABLE:false}
   webhook-url: ${DISCORD_WEBHOOK_WEB_URL}
+
+rabbitmq:
+  batch:
+    # 배치 리스너 관련 설정
+    default-requeue-rejected: false
+    enabled: true       # 배치 리스너 활성화
+    size: 10            # 배치 크기 (10개 메시지)
+    timeout: 1000      # 타임아웃(ms)
+    consumer-batch-enabled: true  # 내부 배치 처리 기능 활성화


### PR DESCRIPTION
## #️⃣연관된 이슈

#275

## 📝작업 내용

- 실시간 경로 추적을 위한 web-queue 추가
  - 실시간으로 hub에 들어오는 주기 정보를 web-queue에 넣으면 web 모듈에서 받아서 sse로 실시간 경로 추적

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
