### PR TITLE
WEB - rent 생성 시 상태에 따른 차량번호 조회 필터링 및 CarStatus 응답 필드 추가

### DIFF
--- a/tracky-core/src/main/java/kernel360/trackycore/core/domain/provider/CarProvider.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/domain/provider/CarProvider.java
@@ -1,6 +1,5 @@
 package kernel360.trackycore.core.domain.provider;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -23,10 +22,6 @@ public class CarProvider {
 
 	public CarEntity findByMdn(String mdn) {
 		return carRepository.findByMdn(mdn).orElseThrow(() -> GlobalException.throwError(ErrorCode.CAR_NOT_FOUND));
-	}
-
-	public List<String> getAllMdnByBizUuid(String bizUuid) {
-		return carRepository.findByBizUuid(bizUuid);
 	}
 
 	public boolean existsByMdn(String mdn) {

--- a/tracky-core/src/main/java/kernel360/trackycore/core/domain/provider/CarProvider.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/domain/provider/CarProvider.java
@@ -25,6 +25,10 @@ public class CarProvider {
 		return carRepository.findByMdn(mdn).orElseThrow(() -> GlobalException.throwError(ErrorCode.CAR_NOT_FOUND));
 	}
 
+	public List<String> getAllMdnByBizUuid(String bizUuid) {
+		return carRepository.findByBizUuid(bizUuid);
+	}
+
 	public boolean existsByMdn(String mdn) {
 		return carRepository.existsByMdn(mdn);
 	}

--- a/tracky-core/src/main/java/kernel360/trackycore/core/infrastructure/repository/CarRepository.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/infrastructure/repository/CarRepository.java
@@ -1,6 +1,5 @@
 package kernel360.trackycore.core.infrastructure.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,11 +21,4 @@ public interface CarRepository extends JpaRepository<CarEntity, Long> {
 	 * @return 차량 단건 조회
 	 */
 	Optional<CarEntity> findByMdn(String mdn);
-
-	/**
-	 * 업체 uuid에 해당하는 차량 리스트 조회
-	 * @param bizUuid 업체 uuid
-	 * @return 차량 리스트 조회
-	 */
-	List<String> findByBizUuid(String bizUuid);
 }

--- a/tracky-core/src/main/java/kernel360/trackycore/core/infrastructure/repository/CarRepository.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/infrastructure/repository/CarRepository.java
@@ -1,5 +1,6 @@
 package kernel360.trackycore.core.infrastructure.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -21,4 +22,11 @@ public interface CarRepository extends JpaRepository<CarEntity, Long> {
 	 * @return 차량 단건 조회
 	 */
 	Optional<CarEntity> findByMdn(String mdn);
+
+	/**
+	 * 업체 uuid에 해당하는 차량 리스트 조회
+	 * @param bizUuid 업체 uuid
+	 * @return 차량 리스트 조회
+	 */
+	List<String> findByBizUuid(String bizUuid);
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/car/domain/provider/CarDomainProvider.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/car/domain/provider/CarDomainProvider.java
@@ -69,7 +69,7 @@ public class CarDomainProvider {
 	public Map<Long, Integer> countDailyTotalCar() {
 		return CarCountWithBizId.toMap(carDomainRepository.getDailyTotalCarCount());
   }
-  
+
 	public List<CarEntity> findAllByAvailableEmulate(String bizUuid) {
 		return carDomainRepository.availableEmulate(bizUuid);
 	 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
@@ -14,6 +14,7 @@ import kernel360.trackycore.core.common.api.ApiResponse;
 import kernel360.trackycore.core.domain.entity.GpsHistoryEntity;
 import kernel360.trackycore.core.domain.entity.RentEntity;
 import kernel360.trackycore.core.domain.entity.enums.CarStatus;
+import kernel360.trackycore.core.domain.entity.enums.RentStatus;
 import kernel360.trackycore.core.domain.provider.CarProvider;
 import kernel360.trackyweb.car.domain.provider.CarDomainProvider;
 import kernel360.trackyweb.dashboard.application.dto.response.ReturnResponse;
@@ -121,5 +122,11 @@ public class DashBoardService {
 		}
 		log.info("provinceCountMap: {}", provinceCountMap);
 		return provinceCountMap;
+	}
+
+	public ApiResponse<String> updateStatusToReturn(String rentUuid) {
+		rentDomainProvider.updateRentStatus(rentUuid, RentStatus.RETURNED);
+
+		return ApiResponse.success("반납 처리 완료");
 	}
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
@@ -49,7 +49,7 @@ public class DashBoardService {
 
 	public ApiResponse<List<ReturnResponse>> getDelayedReturn(String bizUuid) {
 		LocalDateTime now = LocalDateTime.now();
-		List<RentEntity> delayedRents = rentDomainProvider.getDelayedRentList(bizUuid, now);
+		List<RentEntity> delayedRents = rentDomainProvider.findDelayedRentList(bizUuid, now);
 
 		return ApiResponse.success(
 			delayedRents.stream()
@@ -132,7 +132,7 @@ public class DashBoardService {
 		RentEntity rent = rentProvider.getRent(rentUuid);
 
 		rent.updateStatus(RentStatus.RETURNED);
-		
+
 		return ApiResponse.success("반납 처리 완료");
 	}
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
@@ -49,7 +49,7 @@ public class DashBoardService {
 
 	public ApiResponse<List<ReturnResponse>> getDelayedReturn(String bizUuid) {
 		LocalDateTime now = LocalDateTime.now();
-		List<RentEntity> delayedRents = rentDomainProvider.findDelayedRentList(bizUuid, now);
+		List<RentEntity> delayedRents = rentDomainProvider.getDelayedRentList(bizUuid, now);
 
 		return ApiResponse.success(
 			delayedRents.stream()

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
@@ -16,6 +16,7 @@ import kernel360.trackycore.core.domain.entity.RentEntity;
 import kernel360.trackycore.core.domain.entity.enums.CarStatus;
 import kernel360.trackycore.core.domain.entity.enums.RentStatus;
 import kernel360.trackycore.core.domain.provider.CarProvider;
+import kernel360.trackycore.core.domain.provider.RentProvider;
 import kernel360.trackyweb.car.domain.provider.CarDomainProvider;
 import kernel360.trackyweb.dashboard.application.dto.response.ReturnResponse;
 import kernel360.trackyweb.dashboard.domain.CarStatusTemp;
@@ -34,6 +35,7 @@ public class DashBoardService {
 	private final DashGpsHistoryProvider dashGpsHistoryProvider;
 	private final CarProvider carProvider;
 	private final CarDomainProvider carDomainProvider;
+	private final RentProvider rentProvider;
 	private final RentDomainProvider rentDomainProvider;
 	private final DriveDomainProvider driveDomainProvider;
 
@@ -124,9 +126,13 @@ public class DashBoardService {
 		return provinceCountMap;
 	}
 
+	@Transactional
 	public ApiResponse<String> updateStatusToReturn(String rentUuid) {
-		rentDomainProvider.updateRentStatus(rentUuid, RentStatus.RETURNED);
 
+		RentEntity rent = rentProvider.getRent(rentUuid);
+
+		rent.updateStatus(RentStatus.RETURNED);
+		
 		return ApiResponse.success("반납 처리 완료");
 	}
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/presentation/DashBoardController.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/presentation/DashBoardController.java
@@ -42,12 +42,6 @@ public class DashBoardController implements DashBoardApiDocs {
 	public ApiResponse<Statistics> getStatistics() {
 		return ApiResponse.success(dashBoardService.getStatistics());
 	}
-/*
-	@GetMapping("/geo")
-	public ApiResponse<Map<String, Integer>> getGeoData() {
-		Map<String, Integer> geoMap = dashBoardService.getGeoData();
-		return ApiResponse.success(geoMap);
-	}*/
 
 	@PatchMapping("/return/status/{rentUuid}")
 	public ApiResponse<String> updateStatusToReturn(@PathVariable String rentUuid) {

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/presentation/DashBoardController.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/presentation/DashBoardController.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -46,4 +48,9 @@ public class DashBoardController implements DashBoardApiDocs {
 		Map<String, Integer> geoMap = dashBoardService.getGeoData();
 		return ApiResponse.success(geoMap);
 	}*/
+
+	@PatchMapping("/return/status/{rentUuid}")
+	public ApiResponse<String> updateStatusToReturn(@PathVariable String rentUuid) {
+		return dashBoardService.updateStatusToReturn(rentUuid);
+	}
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/application/RentService.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/application/RentService.java
@@ -20,6 +20,7 @@ import kernel360.trackyweb.common.sse.SseEvent;
 import kernel360.trackyweb.rent.application.dto.request.RentCreateRequest;
 import kernel360.trackyweb.rent.application.dto.request.RentSearchByFilterRequest;
 import kernel360.trackyweb.rent.application.dto.request.RentUpdateRequest;
+import kernel360.trackyweb.rent.application.dto.response.RentMdnResponse;
 import kernel360.trackyweb.rent.application.dto.response.RentResponse;
 import kernel360.trackyweb.rent.domain.provider.RentDomainProvider;
 import kernel360.trackyweb.rent.domain.util.UuidGenerator;
@@ -31,8 +32,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class RentService {
 
-	private final RentDomainProvider rentDomainProvider;
 	private final RentProvider rentProvider;
+	private final RentDomainProvider rentDomainProvider;
 	private final CarProvider carProvider;
 	private final GlobalSseEvent globalSseEvent;
 
@@ -41,9 +42,11 @@ public class RentService {
 	 *
 	 * @return mdn list
 	 */
-	public ApiResponse<List<String>> getAllMdnByBizUuid(String bizUuid) {
-		List<String> mdns = carProvider.getAllMdnByBizUuid(bizUuid);
-		return ApiResponse.success(mdns);
+	public ApiResponse<List<RentMdnResponse>> getAllMdnByBizUuid(String bizUuid) {
+
+		List<RentMdnResponse> rentable = rentDomainProvider.getRentableMdnList(bizUuid);
+
+		return ApiResponse.success(rentable);
 	}
 
 	/**

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/application/RentService.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/application/RentService.java
@@ -41,8 +41,8 @@ public class RentService {
 	 *
 	 * @return mdn list
 	 */
-	public ApiResponse<List<String>> getAllMdnByBizId(String bizUuid) {
-		List<String> mdns = rentDomainProvider.getAllMdnByBizId(bizUuid);
+	public ApiResponse<List<String>> getAllMdnByBizUuid(String bizUuid) {
+		List<String> mdns = carProvider.getAllMdnByBizUuid(bizUuid);
 		return ApiResponse.success(mdns);
 	}
 

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/application/dto/response/RentMdnResponse.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/application/dto/response/RentMdnResponse.java
@@ -1,0 +1,9 @@
+package kernel360.trackyweb.rent.application.dto.response;
+
+import kernel360.trackycore.core.domain.entity.enums.CarStatus;
+
+public record RentMdnResponse(
+	String mdn,
+	CarStatus status
+) {
+}

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/domain/provider/RentDomainProvider.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/domain/provider/RentDomainProvider.java
@@ -7,13 +7,17 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
+import com.querydsl.core.Tuple;
+
 import kernel360.trackycore.core.common.exception.ErrorCode;
 import kernel360.trackycore.core.common.exception.GlobalException;
+import kernel360.trackycore.core.domain.entity.QRentEntity;
 import kernel360.trackycore.core.domain.entity.RentEntity;
 import kernel360.trackycore.core.domain.entity.enums.RentStatus;
 import kernel360.trackyweb.car.infrastructure.repository.CarDomainRepository;
 import kernel360.trackyweb.rent.application.dto.request.RentSearchByFilterRequest;
 import kernel360.trackyweb.rent.application.dto.response.OverlappingRentResponse;
+import kernel360.trackyweb.rent.application.dto.response.RentMdnResponse;
 import kernel360.trackyweb.rent.infrastructure.repository.RentDomainRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -65,4 +69,13 @@ public class RentDomainProvider {
 			throw GlobalException.throwError(ErrorCode.RENT_OVERLAP, conflictList);
 		}
 	}
+
+	public List<RentMdnResponse> getRentableMdnList(String bizUuid) {
+		List<Tuple> tuples = rentDomainRepository.findRentableMdn(bizUuid);
+		return tuples.stream().map(tuple -> {
+			return new RentMdnResponse(tuple.get(QRentEntity.rentEntity.car.mdn),
+				tuple.get(QRentEntity.rentEntity.car.status));
+		}).toList();
+	}
+
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/domain/provider/RentDomainProvider.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/domain/provider/RentDomainProvider.java
@@ -24,19 +24,16 @@ public class RentDomainProvider {
 	private final RentDomainRepository rentDomainRepository;
 	private final CarDomainRepository carDomainRepository;
 
-	public Page<RentEntity> searchRentByFilter(RentSearchByFilterRequest request, String bizUuid) {
-		return rentDomainRepository.searchRentByFilter(request, bizUuid);
-	}
-
 	public RentEntity save(RentEntity rent) {
 		return rentDomainRepository.save(rent);
 	}
 
-	// public void delete(String rentUuid) { rentDomainRepository.deleteByRentUuid(rentUuid); }
-	public void softDelete(String rentUuid) {
-		RentEntity rent = rentDomainRepository.findByRentUuid(rentUuid)
-			.orElseThrow(() -> GlobalException.throwError(ErrorCode.RENT_NOT_FOUND));
-		rent.updateStatus(RentStatus.DELETED);
+	public Long count() {
+		return rentDomainRepository.count();
+	}
+
+	public Page<RentEntity> searchRentByFilter(RentSearchByFilterRequest request, String bizUuid) {
+		return rentDomainRepository.searchRentByFilter(request, bizUuid);
 	}
 
 	public List<String> getAllMdnByBizId(String bizUuid) {
@@ -51,8 +48,19 @@ public class RentDomainProvider {
 		return rentDomainRepository.getTotalRentDurationInMinutes();
 	}
 
-	public Long count() {
-		return rentDomainRepository.count();
+	public void updateRentStatus(String rentUuid, RentStatus rentStatus) {
+		RentEntity rent = rentDomainRepository.findByRentUuid(rentUuid)
+			.orElseThrow(() -> GlobalException.throwError(ErrorCode.RENT_NOT_FOUND));
+
+		rent.updateStatus(rentStatus);
+
+		rentDomainRepository.save(rent);
+	}
+
+	public void softDelete(String rentUuid) {
+		RentEntity rent = rentDomainRepository.findByRentUuid(rentUuid)
+			.orElseThrow(() -> GlobalException.throwError(ErrorCode.RENT_NOT_FOUND));
+		rent.updateStatus(RentStatus.DELETED);
 	}
 
 	public void validateOverlappingRent(String mdn, LocalDateTime rentStime, LocalDateTime rentEtime) {

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/domain/provider/RentDomainProvider.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/domain/provider/RentDomainProvider.java
@@ -48,15 +48,6 @@ public class RentDomainProvider {
 		return rentDomainRepository.getTotalRentDurationInMinutes();
 	}
 
-	public void updateRentStatus(String rentUuid, RentStatus rentStatus) {
-		RentEntity rent = rentDomainRepository.findByRentUuid(rentUuid)
-			.orElseThrow(() -> GlobalException.throwError(ErrorCode.RENT_NOT_FOUND));
-
-		rent.updateStatus(rentStatus);
-
-		rentDomainRepository.save(rent);
-	}
-
 	public void softDelete(String rentUuid) {
 		RentEntity rent = rentDomainRepository.findByRentUuid(rentUuid)
 			.orElseThrow(() -> GlobalException.throwError(ErrorCode.RENT_NOT_FOUND));

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/infrastructure/repository/RentRepositoryCustom.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/infrastructure/repository/RentRepositoryCustom.java
@@ -5,11 +5,15 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 
+import com.querydsl.core.Tuple;
+
 import kernel360.trackycore.core.domain.entity.RentEntity;
 import kernel360.trackyweb.rent.application.dto.request.RentSearchByFilterRequest;
 
 public interface RentRepositoryCustom {
 	Page<RentEntity> searchRentByFilter(RentSearchByFilterRequest request, String bizUuid);
+
+	List<Tuple> findRentableMdn(String bizUuid);
 
 	List<RentEntity> findDelayedRents(String bizUuid, LocalDateTime now);
 

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/infrastructure/repository/RentRepositoryCustomImpl.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/infrastructure/repository/RentRepositoryCustomImpl.java
@@ -61,16 +61,15 @@ public class RentRepositoryCustomImpl implements RentRepositoryCustom {
 
 	@Override
 	public List<Tuple> findRentableMdn(String bizUuid) {
-		QRentEntity rent = QRentEntity.rentEntity;
 
 		return queryFactory
-			.select(rent.car.mdn, rent.car.status)
+			.select(rentEntity.car.mdn, rentEntity.car.status)
 			.distinct()
-			.from(rent)
+			.from(rentEntity)
 			.where(
-				rent.car.biz.bizUuid.eq(bizUuid),
-				rent.car.status.ne(CarStatus.CLOSED),
-				rent.car.status.ne(CarStatus.DELETED)
+				rentEntity.car.biz.bizUuid.eq(bizUuid),
+				rentEntity.car.status.ne(CarStatus.CLOSED),
+				rentEntity.car.status.ne(CarStatus.DELETED)
 			)
 			.fetch();
 	}
@@ -118,18 +117,16 @@ public class RentRepositoryCustomImpl implements RentRepositoryCustom {
 
 	@Override
 	public List<RentEntity> findDelayedRents(String bizUuid, LocalDateTime now) {
-		QRentEntity rent = QRentEntity.rentEntity;
 
 		return queryFactory
-			.selectFrom(rent)
+			.selectFrom(rentEntity)
 			.where(
-				rent.rentStatus.eq(RentStatus.RENTING),
-				rent.rentEtime.before(now),
-				rent.car.biz.bizUuid.eq(bizUuid)
+				rentEntity.rentStatus.eq(RentStatus.RENTING),
+				rentEntity.rentEtime.before(now),
+				rentEntity.car.biz.bizUuid.eq(bizUuid)
 			)
 			.fetch();
 	}
-
 
 	@Override
 	public List<RentEntity> findOverlappingRent(String mdn, LocalDateTime start, LocalDateTime end) {

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/infrastructure/repository/RentRepositoryCustomImpl.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/infrastructure/repository/RentRepositoryCustomImpl.java
@@ -13,11 +13,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kernel360.trackycore.core.domain.entity.QRentEntity;
 import kernel360.trackycore.core.domain.entity.RentEntity;
+import kernel360.trackycore.core.domain.entity.enums.CarStatus;
 import kernel360.trackycore.core.domain.entity.enums.RentStatus;
 import kernel360.trackyweb.rent.application.dto.request.RentSearchByFilterRequest;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +57,22 @@ public class RentRepositoryCustomImpl implements RentRepositoryCustom {
 		).orElse(0L);
 
 		return new PageImpl<>(content, pageable, total);
+	}
+
+	@Override
+	public List<Tuple> findRentableMdn(String bizUuid) {
+		QRentEntity rent = QRentEntity.rentEntity;
+
+		return queryFactory
+			.select(rent.car.mdn, rent.car.status)
+			.distinct()
+			.from(rent)
+			.where(
+				rent.car.biz.bizUuid.eq(bizUuid),
+				rent.car.status.ne(CarStatus.CLOSED),
+				rent.car.status.ne(CarStatus.DELETED)
+			)
+			.fetch();
 	}
 
 	private BooleanBuilder isNotDeleted(RentStatus status) {

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/presentation/RentApiDocs.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/presentation/RentApiDocs.java
@@ -14,6 +14,7 @@ import kernel360.trackycore.core.common.api.ApiResponse;
 import kernel360.trackyweb.rent.application.dto.request.RentCreateRequest;
 import kernel360.trackyweb.rent.application.dto.request.RentSearchByFilterRequest;
 import kernel360.trackyweb.rent.application.dto.request.RentUpdateRequest;
+import kernel360.trackyweb.rent.application.dto.response.RentMdnResponse;
 import kernel360.trackyweb.rent.application.dto.response.RentResponse;
 import kernel360.trackyweb.sign.infrastructure.security.principal.MemberPrincipal;
 
@@ -21,7 +22,7 @@ import kernel360.trackyweb.sign.infrastructure.security.principal.MemberPrincipa
 public interface RentApiDocs {
 
 	@Operation(summary = "rent 등록시 select 할 차량 전체 목록", description = "rent 등록시 select 할 차량 전체 목록 list")
-	ApiResponse<List<String>> getAllMdnByBizId(
+	ApiResponse<List<RentMdnResponse>> getAllMdnByBizId(
 		@Schema(hidden = true) @AuthenticationPrincipal MemberPrincipal memberPrincipal
 	);
 

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/presentation/RentController.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/presentation/RentController.java
@@ -19,6 +19,7 @@ import kernel360.trackyweb.rent.application.RentService;
 import kernel360.trackyweb.rent.application.dto.request.RentCreateRequest;
 import kernel360.trackyweb.rent.application.dto.request.RentSearchByFilterRequest;
 import kernel360.trackyweb.rent.application.dto.request.RentUpdateRequest;
+import kernel360.trackyweb.rent.application.dto.response.RentMdnResponse;
 import kernel360.trackyweb.rent.application.dto.response.RentResponse;
 import kernel360.trackyweb.sign.infrastructure.security.principal.MemberPrincipal;
 import lombok.RequiredArgsConstructor;
@@ -33,10 +34,11 @@ public class RentController implements RentApiDocs {
 	private final RentService rentService;
 
 	@GetMapping("/mdns")
-	public ApiResponse<List<String>> getAllMdnByBizId(
+	public ApiResponse<List<RentMdnResponse>> getAllMdnByBizId(
 		@Schema(hidden = true) @AuthenticationPrincipal MemberPrincipal memberPrincipal
 	) {
 		String bizUuid = memberPrincipal.bizUuid();
+
 		return rentService.getAllMdnByBizUuid(bizUuid);
 	}
 

--- a/tracky-web/src/main/java/kernel360/trackyweb/rent/presentation/RentController.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/rent/presentation/RentController.java
@@ -37,7 +37,7 @@ public class RentController implements RentApiDocs {
 		@Schema(hidden = true) @AuthenticationPrincipal MemberPrincipal memberPrincipal
 	) {
 		String bizUuid = memberPrincipal.bizUuid();
-		return rentService.getAllMdnByBizId(bizUuid);
+		return rentService.getAllMdnByBizUuid(bizUuid);
 	}
 
 	@GetMapping()

--- a/tracky-web/src/main/resources/application.yml
+++ b/tracky-web/src/main/resources/application.yml
@@ -21,6 +21,10 @@ spring:
       org.hibernate.SQL: debug            # SQL 쿼리
       org.hibernate.type.descriptor.sql: trace   # 파라미터 값까지 출력
 
+  jackson:
+    mapper:
+      accept-case-insensitive-enums: true
+
 discord:
   enable: ${DISCORD_WEBHOOK_ENABLE:false}
   webhook-url: ${DISCORD_WEBHOOK_WEB_URL}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #297 

## 📝작업 내용

rents/mdns API를 대대적으로 수정했습니다.
대여 가능한 차량 목록을 필터링하는 findRentableMdn 쿼리 작성(querydsl)
반환값을 List<Tuple>로 받아 Provider에서 stream -> 응답DTO로 변환하는 과정을 거치도록 구현해 보았습니다
이제 프론트에서 차량번호 목록과 함께 차량 상태가 보이게 됩니다 (프론트 develop에 병합 필요)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
