### PR TITLE
WEB - 스케줄러를 통한 RentStatus 업데이트 기능 추가

### DIFF
--- a/tracky-core/src/main/java/kernel360/trackycore/core/domain/provider/RentProvider.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/domain/provider/RentProvider.java
@@ -1,10 +1,13 @@
 package kernel360.trackycore.core.domain.provider;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import kernel360.trackycore.core.common.exception.ErrorCode;
 import kernel360.trackycore.core.common.exception.GlobalException;
 import kernel360.trackycore.core.domain.entity.RentEntity;
+import kernel360.trackycore.core.domain.entity.enums.RentStatus;
 import kernel360.trackycore.core.infrastructure.repository.RentRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -17,5 +20,9 @@ public class RentProvider {
 	public RentEntity getRent(String rentUuid) {
 		return rentRepository.findByRentUuid(rentUuid)
 			.orElseThrow(() -> GlobalException.throwError(ErrorCode.RENT_NOT_FOUND));
+	}
+
+	public List<RentEntity> getByStatus(RentStatus rentStatus) {
+		return rentRepository.findAllByRentStatus(rentStatus);
 	}
 }

--- a/tracky-core/src/main/java/kernel360/trackycore/core/infrastructure/repository/RentRepository.java
+++ b/tracky-core/src/main/java/kernel360/trackycore/core/infrastructure/repository/RentRepository.java
@@ -1,11 +1,15 @@
 package kernel360.trackycore.core.infrastructure.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kernel360.trackycore.core.domain.entity.RentEntity;
+import kernel360.trackycore.core.domain.entity.enums.RentStatus;
 
 public interface RentRepository extends JpaRepository<RentEntity, Long> {
 	Optional<RentEntity> findByRentUuid(String rentUuid);
+
+	List<RentEntity> findAllByRentStatus(RentStatus rentStatus);
 }

--- a/tracky-core/src/main/resources/application-common.yml
+++ b/tracky-core/src/main/resources/application-common.yml
@@ -39,3 +39,10 @@ management:
       exposure:
         include:
           - "*"
+          
+logging:
+  level:
+    # RabbitMQ ConnectionFactory INFO 로그 끄기
+    org.springframework.amqp.rabbit.connection.CachingConnectionFactory: OFF
+    # RabbitMQ Listener INFO 로그 끄기
+    org.springframework.amqp.rabbit.listener: OFF

--- a/tracky-web/src/main/java/kernel360/trackyweb/TrackyWebApplication.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/TrackyWebApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EntityScan(basePackages = "kernel360")
 @ComponentScan(basePackages = "kernel360")
 @EnableJpaRepositories(basePackages = "kernel360")
+@EnableScheduling
 public class TrackyWebApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(TrackyWebApplication.class, args);

--- a/tracky-web/src/main/java/kernel360/trackyweb/car/application/CarService.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/car/application/CarService.java
@@ -23,10 +23,8 @@ import kernel360.trackyweb.car.application.dto.response.CarDetailResponse;
 import kernel360.trackyweb.car.application.dto.response.CarResponse;
 import kernel360.trackyweb.car.application.dto.response.MdnWithBizResponse;
 import kernel360.trackyweb.car.domain.provider.CarDomainProvider;
-import kernel360.trackyweb.car.domain.provider.MdnStatus;
 import kernel360.trackyweb.car.infrastructure.util.ExcelGenerator;
 import kernel360.trackyweb.common.sse.GlobalSseEvent;
-import kernel360.trackyweb.dashboard.domain.CarStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/tracky-web/src/main/java/kernel360/trackyweb/car/infrastructure/repository/CarDomainRepositoryCustomImpl.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/car/infrastructure/repository/CarDomainRepositoryCustomImpl.java
@@ -2,6 +2,7 @@ package kernel360.trackyweb.car.infrastructure.repository;
 
 import static kernel360.trackycore.core.domain.entity.QBizEntity.*;
 import static kernel360.trackycore.core.domain.entity.QCarEntity.*;
+import static kernel360.trackycore.core.domain.entity.QRentEntity.*;
 
 import java.time.LocalDateTime;
 import java.util.List;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #305 

## 📝작업 내용

> @Scheduled를 통해 1분마다 RentStatus를 RESERVED 에서 RENTING으로 업데이트하는 메서드 추가했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
