### PR TITLE
WEB - 프론트 소문자 enum값 허용해주는 설정 추가

### DIFF
--- a/tracky-core/src/main/resources/application-common.yml
+++ b/tracky-core/src/main/resources/application-common.yml
@@ -39,3 +39,7 @@ management:
       exposure:
         include:
           - "*"
+logging:
+  level:
+    org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer: ERROR
+    org.springframework.amqp.rabbit.connection.CachingConnectionFactory: ERROR

--- a/tracky-web/src/main/resources/application.yml
+++ b/tracky-web/src/main/resources/application.yml
@@ -21,6 +21,10 @@ spring:
       org.hibernate.SQL: debug            # SQL 쿼리
       org.hibernate.type.descriptor.sql: trace   # 파라미터 값까지 출력
 
+  jackson:
+    mapper:
+      accept-case-insensitive-enums: true
+
 discord:
   enable: ${DISCORD_WEBHOOK_ENABLE:false}
   webhook-url: ${DISCORD_WEBHOOK_WEB_URL}


### PR DESCRIPTION
## 📝작업 내용

프론트에서 enum값이 소문자로 되어있어 web 모듈 application.yml 에 관련 설정 추가했습니다
application-common에도 적용해 보았으나 작동하지 않아서 web 모듈 파일에 적용했습니다
추가로 rabbitMQ 관련 경고 로그가 1초마다 계속 올라오는데 그거 꺼버리는 설정도 넣었습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
