### PR TITLE
WEB - 대시보드 차량 위치 지도 쿼리 최적화 및 응답 형식 변경

### DIFF
--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/application/DashBoardService.java
@@ -1,6 +1,7 @@
 package kernel360.trackyweb.dashboard.application;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -8,7 +9,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StopWatch;
 
 import kernel360.trackycore.core.common.api.ApiResponse;
 import kernel360.trackycore.core.domain.entity.GpsHistoryEntity;
@@ -90,38 +90,28 @@ public class DashBoardService {
 	 * @return 구역 : 차량 수 map
 	 */
 	@Transactional(readOnly = true)
-	public Map<String, Integer> getGeoData(String bizUuid) {
+	public Map<String, List<String>> getGeoData(String bizUuid) {
 
-		StopWatch stopWatch = new StopWatch();
-
-		//1
-		stopWatch.start("작업 1");
-		List<GpsHistoryEntity> gpsList = dashGpsHistoryProvider.findLatestGpsByMdn(bizUuid);
-		stopWatch.stop();
+		List<GpsHistoryEntity> gpsList = dashGpsHistoryProvider.findLatestGps(bizUuid);
 
 		log.info("gpsList: {} ", gpsList);
 
-		Map<String, Integer> provinceCountMap = new HashMap<>();
+		Map<String, List<String>> provinceCountMap = new HashMap<>();
 
-		//2
-		stopWatch.start("작업 2");
 		for (GpsHistoryEntity gps : gpsList) {
 			// DB에 저장된 위도/경도는 정수형이므로 소수로 변환 필요
 			double lat = gps.getLat() / 1_000_000.0;
 			double lon = gps.getLon() / 1_000_000.0;
 
 			String province = provinceMatcher.findProvince(lon, lat);
+			String mdn = gps.getDrive().getCar().getMdn();
 
-			provinceCountMap.put(province, provinceCountMap.getOrDefault(province, 0) + 1);
+			provinceCountMap
+				.computeIfAbsent(province, k -> new ArrayList<>())
+				.add(mdn);
 		}
-		stopWatch.stop();
 
-		// 성능 분석 로그
-		log.info("=== 성능 분석 결과 ===");
-		log.info("전체 실행 시간: {}ms", stopWatch.getTotalTimeMillis());
 		log.info("처리된 GPS 데이터: {}개", gpsList.size());
-		log.info("\n{}", stopWatch.prettyPrint());
-
 		log.info("provinceCountMap: {}", provinceCountMap);
 		return provinceCountMap;
 	}

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/domain/provider/DashGpsHistoryProvider.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/domain/provider/DashGpsHistoryProvider.java
@@ -14,7 +14,7 @@ public class DashGpsHistoryProvider {
 
 	private final DashGpsHistoryRepository dashGpsHistoryRepository;
 
-	public List<GpsHistoryEntity> findLatestGpsByMdn(String bizUuid) {
+	public List<GpsHistoryEntity> findLatestGps(String bizUuid) {
 		return dashGpsHistoryRepository.getLatestGps(bizUuid);
 	}
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/domain/provider/DashGpsHistoryProvider.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/domain/provider/DashGpsHistoryProvider.java
@@ -14,7 +14,7 @@ public class DashGpsHistoryProvider {
 
 	private final DashGpsHistoryRepository dashGpsHistoryRepository;
 
-	public List<GpsHistoryEntity> findLatestGpsByMdn() {
-		return dashGpsHistoryRepository.findLatestGpsByMdn();
+	public List<GpsHistoryEntity> findLatestGpsByMdn(String bizUuid) {
+		return dashGpsHistoryRepository.getLatestGps(bizUuid);
 	}
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/infrastructure/repository/DashGpsHistoryRepository.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/infrastructure/repository/DashGpsHistoryRepository.java
@@ -1,27 +1,10 @@
 package kernel360.trackyweb.dashboard.infrastructure.repository;
 
-import java.util.List;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import kernel360.trackycore.core.domain.entity.GpsHistoryEntity;
 import kernel360.trackycore.core.infrastructure.repository.GpsHistoryRepository;
 
 @Repository
-public interface DashGpsHistoryRepository extends GpsHistoryRepository {
-
-	@Query(value = """
-		SELECT *
-		FROM (
-		  SELECT g.*, d.mdn,
-		         ROW_NUMBER() OVER (PARTITION BY d.mdn ORDER BY g.created_at DESC) AS rn
-		  FROM gpshistory g
-		  JOIN drive d ON g.drive_id = d.id
-		) t
-		WHERE t.rn = 1
-		""", nativeQuery = true)
-	List<GpsHistoryEntity> findLatestGpsByMdn();
+public interface DashGpsHistoryRepository extends GpsHistoryRepository, DashGpsHistoryRepositoryCustom {
 
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/infrastructure/repository/DashGpsHistoryRepositoryCustomImpl.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/infrastructure/repository/DashGpsHistoryRepositoryCustomImpl.java
@@ -1,15 +1,15 @@
 package kernel360.trackyweb.dashboard.infrastructure.repository;
 
+import static kernel360.trackycore.core.domain.entity.QBizEntity.*;
+import static kernel360.trackycore.core.domain.entity.QCarEntity.*;
 import static kernel360.trackycore.core.domain.entity.QDriveEntity.*;
 import static kernel360.trackycore.core.domain.entity.QGpsHistoryEntity.*;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
 
-import com.querydsl.core.Tuple;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import kernel360.trackycore.core.domain.entity.GpsHistoryEntity;
@@ -21,33 +21,32 @@ public class DashGpsHistoryRepositoryCustomImpl implements DashGpsHistoryReposit
 
 	private final JPAQueryFactory queryFactory;
 
+	/**
+	 * 대시보드 차량 위치 지도 - 업체별 최신 GPS 조회
+	 * @param bizUuid
+	 * @return
+	 */
 	@Override
 	public List<GpsHistoryEntity> getLatestGps(String bizUuid) {
-		// 1. 각 MDN별 최신 GPS ID 조회
-		List<Tuple> latestGpsInfo = queryFactory
-			.select(driveEntity.car.mdn, gpsHistoryEntity.driveSeq.max())
-			.from(gpsHistoryEntity)
-			.join(driveEntity).on(gpsHistoryEntity.drive.id.eq(driveEntity.id))
-			.where(driveEntity.car.biz.bizUuid.eq(bizUuid))
-			.groupBy(driveEntity.car.mdn)
-			.fetch();
-
-		// 2. 최신 GPS ID들로 실제 엔티티 조회
-		List<UUID> latestGpsIds = latestGpsInfo.stream()
-			.map(tuple -> tuple.get(gpsHistoryEntity.driveSeq.max()))
-			.toList();
-
-		if (latestGpsIds.isEmpty()) {
-			return Collections.emptyList();
-		}
 
 		return queryFactory
-			.selectFrom(gpsHistoryEntity)
-			.join(driveEntity).on(gpsHistoryEntity.drive.id.eq(driveEntity.id))
+			.select(gpsHistoryEntity)
+			.from(gpsHistoryEntity)
+			.join(gpsHistoryEntity.drive, driveEntity)
 			.where(
-				gpsHistoryEntity.driveSeq.in(latestGpsIds),
-				driveEntity.car.biz.bizUuid.eq(bizUuid)
+				// bizUuid 필터링 + MDN별 최신 drive.id 서브쿼리
+				gpsHistoryEntity.drive.id.in(
+					JPAExpressions
+						.select(driveEntity.id.max())
+						.from(driveEntity)
+						.join(driveEntity.car, carEntity)
+						.join(carEntity.biz, bizEntity)
+						.where(bizEntity.bizUuid.eq(bizUuid))
+						.groupBy(carEntity.mdn)
+				)
 			)
+			.groupBy(driveEntity.id, driveEntity.car.mdn)
+			.orderBy(gpsHistoryEntity.driveSeq.desc())
 			.fetch();
 	}
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/presentation/DashBoardController.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/presentation/DashBoardController.java
@@ -51,10 +51,10 @@ public class DashBoardController implements DashBoardApiDocs {
 	}
 
 	@GetMapping("/geo")
-	public ApiResponse<Map<String, Integer>> getGeoData(
+	public ApiResponse<Map<String, List<String>>> getGeoData(
 		@Schema(hidden = true) @AuthenticationPrincipal MemberPrincipal memberPrincipal
 	) {
-		Map<String, Integer> geoMap = dashBoardService.getGeoData(memberPrincipal.bizUuid());
+		Map<String, List<String>> geoMap = dashBoardService.getGeoData(memberPrincipal.bizUuid());
 		return ApiResponse.success(geoMap);
 	}
 }

--- a/tracky-web/src/main/java/kernel360/trackyweb/dashboard/presentation/DashBoardController.java
+++ b/tracky-web/src/main/java/kernel360/trackyweb/dashboard/presentation/DashBoardController.java
@@ -51,8 +51,10 @@ public class DashBoardController implements DashBoardApiDocs {
 	}
 
 	@GetMapping("/geo")
-	public ApiResponse<Map<String, Integer>> getGeoData() {
-		Map<String, Integer> geoMap = dashBoardService.getGeoData();
+	public ApiResponse<Map<String, Integer>> getGeoData(
+		@Schema(hidden = true) @AuthenticationPrincipal MemberPrincipal memberPrincipal
+	) {
+		Map<String, Integer> geoMap = dashBoardService.getGeoData(memberPrincipal.bizUuid());
 		return ApiResponse.success(geoMap);
 	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #342 

## 📝작업 내용

쿼리 최적화 진행, 응답 속도 30% 개선

gpshistory 테이블에 (drive_id, drive_seq) 복합 인덱스 추가

지도에 내리는 응답을 차량 정수가 아닌 mdn의 List로 변경
